### PR TITLE
Improve client API handling

### DIFF
--- a/src/client/src/api/apiClient.ts
+++ b/src/client/src/api/apiClient.ts
@@ -1,322 +1,143 @@
-import { API_TIMEOUT } from '../config/constants';
-import { setToken, removeToken, getToken } from '../utils/authHelpers';
-import { router } from '../routes/Router';
-import { ApiError, ApiResponse } from '../types/common/ApiResponse';
+import axios, {
+  AxiosInstance,
+  AxiosRequestConfig,
+  AxiosError,
+} from 'axios';
 import { API_BASE_URL, AUTH_ENDPOINTS } from '../config/endpoints';
-
-// Interfaces für Request/Response
-interface RequestConfig {
-  method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
-  headers?: Record<string, string>;
-  body?: unknown;
-  timeout?: number;
-  _retry?: boolean;
-}
-
-// interface ApiResponse<T> {
-//   data: T;
-//   status: number;
-//   statusText: string;
-//   headers: Headers;
-// }
-
-interface ApiErrorResponse extends Error {
-  response?: {
-    status: number;
-    data: ApiError;
-  };
-  request?: {
-    url: string;
-    config: RequestConfig;
-  };
-}
+import { API_TIMEOUT } from '../config/constants';
+import {
+  getToken,
+  getRefreshToken,
+  setToken,
+  setRefreshToken,
+  removeToken,
+} from '../utils/authHelpers';
+import { router } from '../routes/Router';
+import { ApiResponse } from '../types/common/ApiResponse';
 
 interface TokenRefreshResponse {
   token: string;
+  refreshToken: string;
+}
+
+interface ExtendedAxiosRequestConfig<T = unknown> extends AxiosRequestConfig<T> {
+  _retry?: boolean;
 }
 
 class ApiClient {
-  private baseURL: string;
-  private defaultHeaders: Record<string, string>;
-  private timeout: number;
+  private axios: AxiosInstance;
   private isRefreshing = false;
-  private refreshSubscribers: ((token: string) => void)[] = [];
+  private refreshSubscribers: Array<(token: string) => void> = [];
 
-  constructor(
-    baseURL: string,
-    defaultHeaders: Record<string, string>,
-    timeout: number
-  ) {
-    this.baseURL = baseURL;
-    this.defaultHeaders = defaultHeaders;
-    this.timeout = timeout;
+  constructor() {
+    this.axios = axios.create({
+      baseURL: API_BASE_URL,
+      timeout: API_TIMEOUT,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    this.axios.interceptors.request.use((config) => {
+      const token = getToken();
+      if (token && config.headers) {
+        // eslint-disable-next-line no-param-reassign
+        config.headers.Authorization = `Bearer ${token}`;
+      }
+      return config;
+    });
+
+    this.axios.interceptors.response.use(
+      (response) => response,
+      (error) => this.handleError(error)
+    );
   }
 
-  private subscribeTokenRefresh(cb: (token: string) => void): void {
+  private subscribeTokenRefresh(cb: (token: string) => void) {
     this.refreshSubscribers.push(cb);
   }
 
-  private onRefreshed(token: string): void {
+  private onRefreshed(token: string) {
     this.refreshSubscribers.forEach((cb) => cb(token));
     this.refreshSubscribers = [];
   }
 
-  private async request<T>(
-    url: string,
-    config: RequestConfig = {}
-  ): Promise<ApiResponse<T>> {
-    const fullUrl = url.startsWith('http') ? url : `${this.baseURL}${url}`;
-
-    // Headers zusammenführen
-    const headers = {
-      ...this.defaultHeaders,
-      ...config.headers,
-    };
-
-    // Token hinzufügen falls vorhanden
-    const token = getToken();
-    if (token) {
-      headers.Authorization = `Bearer ${token}`;
-    }
-
-    // Request-Logging (Development)
-    if (import.meta.env.DEV) {
-      console.log('[Request]', {
-        url: fullUrl,
-        method: config.method || 'GET',
-        headers,
-        body: config.body,
-      });
-    }
-
-    // AbortController für Timeout
-    const controller = new AbortController();
-    const timeoutId = setTimeout(
-      () => controller.abort(),
-      config.timeout || this.timeout
+  private async refreshAccessToken(): Promise<TokenRefreshResponse> {
+    const response = await this.axios.post<ApiResponse<TokenRefreshResponse>>(
+      AUTH_ENDPOINTS.REFRESH_TOKEN,
+      {
+        token: getToken(),
+        refreshToken: getRefreshToken(),
+      }
     );
-
-    try {
-      const fetchConfig: RequestInit = {
-        method: config.method || 'GET',
-        headers,
-        signal: controller.signal,
-      };
-
-      // Body nur bei POST/PUT/PATCH hinzufügen
-      if (
-        config.body &&
-        ['POST', 'PUT', 'PATCH'].includes(config.method?.toUpperCase() || '')
-      ) {
-        fetchConfig.body =
-          typeof config.body === 'string'
-            ? config.body
-            : JSON.stringify(config.body);
-      }
-
-      const response = await fetch(fullUrl, fetchConfig);
-      clearTimeout(timeoutId);
-
-      // Content-Type prüfen für JSON-Parsing
-      const contentType = response.headers.get('content-type');
-      const isJson = contentType?.includes('application/json');
-
-      let data: T;
-      if (isJson) {
-        const jsonData = await response.json();
-        data = jsonData as T;
-      } else {
-        const textData = await response.text();
-        data = textData as T;
-      }
-
-      const apiResponse: ApiResponse<T> = {
-        data,
-        success: response.ok,
-        message: response.statusText,
-      };
-
-      // Response-Logging (Development)
-      if (import.meta.env.DEV) {
-        console.log('[Response]', apiResponse);
-      }
-
-      // Fehlerbehandlung für HTTP-Fehler
-      if (!response.ok) {
-        await this.handleHttpError(response, data, config, url);
-      }
-
-      return apiResponse;
-    } catch (error) {
-      clearTimeout(timeoutId);
-      return this.handleRequestError(error, config, url);
-    }
+    const tokenData = response.data.data;
+    setToken(tokenData.token);
+    setRefreshToken(tokenData.refreshToken);
+    return tokenData;
   }
 
-  private async handleHttpError<T>(
-    response: Response,
-    data: T,
-    originalConfig: RequestConfig,
-    url: string
-  ): Promise<ApiResponse<T>> {
-    // 401 Unauthorized - Token Refresh
-    if (response.status === 401 && !originalConfig._retry) {
-      originalConfig._retry = true;
+  private async handleError(error: unknown) {
+    if (axios.isAxiosError(error)) {
+      const originalConfig = error.config as ExtendedAxiosRequestConfig;
+      if (error.response?.status === 401 && !originalConfig._retry) {
+        originalConfig._retry = true;
 
-      if (!this.isRefreshing) {
-        this.isRefreshing = true;
-
-        try {
-          const refreshResponse = await this.request<TokenRefreshResponse>(
-            AUTH_ENDPOINTS.REFRESH_TOKEN,
-            {
-              method: 'POST',
-              body: { token: getToken() },
-            }
-          );
-
-          setToken(refreshResponse.data.token);
-          this.onRefreshed(refreshResponse.data.token);
-          this.isRefreshing = false;
-
-          // Original Request wiederholen
-          return await this.request(url, originalConfig);
-        } catch (refreshError) {
-          this.isRefreshing = false;
-          removeToken();
-          router.navigate('/login');
-          throw refreshError;
-        }
-      }
-
-      // Auf Token-Refresh warten
-      return new Promise((resolve, reject) => {
-        this.subscribeTokenRefresh(async (token: string) => {
+        if (!this.isRefreshing) {
+          this.isRefreshing = true;
           try {
-            const retryConfig = {
-              ...originalConfig,
-              headers: {
-                ...originalConfig.headers,
-                Authorization: `Bearer ${token}`,
-              },
-            };
-            const result = await this.request<T>(url, retryConfig);
-            resolve(result);
-          } catch (error) {
-            reject(error);
+            const tokenData = await this.refreshAccessToken();
+            this.onRefreshed(tokenData.token);
+            this.isRefreshing = false;
+          } catch (refreshError) {
+            this.isRefreshing = false;
+            removeToken();
+            router.navigate('/login');
+            return Promise.reject(refreshError);
           }
-        });
-      });
-    }
+        }
 
-    // Andere HTTP-Fehler
-    const apiError = this.isApiError(data)
-      ? data
-      : { message: 'Ein Fehler ist aufgetreten' };
-
-    const error = new Error(apiError.message) as ApiErrorResponse;
-    error.response = {
-      status: response.status,
-      data: apiError,
-    };
-
-    throw error;
-  }
-
-  private isApiError(data: unknown): data is ApiError {
-    return (
-      typeof data === 'object' &&
-      data !== null &&
-      'message' in data &&
-      typeof (data as Record<string, unknown>).message === 'string'
-    );
-  }
-
-  private async handleRequestError(
-    error: unknown,
-    config: RequestConfig,
-    url: string
-  ): Promise<ApiResponse<never>> {
-    // Timeout oder Netzwerkfehler
-    if (error instanceof Error && error.name === 'AbortError') {
-      throw new Error('Request-Timeout erreicht');
-    }
-
-    // Netzwerkfehler
-    if (error instanceof TypeError && error.message.includes('fetch')) {
-      // Entwicklungsmodus: Fallback statt harter Fehler
-      if (import.meta.env.DEV) {
-        console.warn(
-          '[Dev Fallback] Keine Serverantwort. Fallback-Antwort wird zurückgegeben.'
-        );
-        return Promise.resolve({
-          data: {} as never, // Explizit never für Fallback
-          status: 200,
-          success: true,
-          statusText: 'OK (Fallback)',
-          headers: new Headers(),
+        return new Promise((resolve, reject) => {
+          this.subscribeTokenRefresh((token) => {
+            if (originalConfig.headers) {
+              originalConfig.headers.Authorization = `Bearer ${token}`;
+            }
+            this.axios(originalConfig)
+              .then(resolve)
+              .catch(reject);
+          });
         });
       }
-
-      const networkError = new Error(
-        'Netzwerkfehler. Bitte überprüfe deine Verbindung.'
-      ) as ApiErrorResponse;
-      networkError.request = { url, config };
-      throw networkError;
     }
-
-    if (error instanceof Error) {
-      throw error;
-    }
-
-    throw new Error('Unbekannter Fehler aufgetreten');
+    return Promise.reject(error);
   }
 
-  // HTTP-Methoden
-  async get<T>(
-    url: string,
-    config?: Omit<RequestConfig, 'method'>
-  ): Promise<ApiResponse<T>> {
-    return this.request<T>(url, { ...config, method: 'GET' });
+  get<T>(url: string, config?: AxiosRequestConfig) {
+    return this.axios
+      .get<ApiResponse<T>>(url, config)
+      .then((res) => res.data);
   }
 
-  async post<T>(
-    url: string,
-    data?: unknown,
-    config?: Omit<RequestConfig, 'method' | 'body'>
-  ): Promise<ApiResponse<T>> {
-    return this.request<T>(url, { ...config, method: 'POST', body: data });
+  post<T>(url: string, data?: unknown, config?: AxiosRequestConfig) {
+    return this.axios
+      .post<ApiResponse<T>>(url, data, config)
+      .then((res) => res.data);
   }
 
-  async put<T>(
-    url: string,
-    data?: unknown,
-    config?: Omit<RequestConfig, 'method' | 'body'>
-  ): Promise<ApiResponse<T>> {
-    return this.request<T>(url, { ...config, method: 'PUT', body: data });
+  put<T>(url: string, data?: unknown, config?: AxiosRequestConfig) {
+    return this.axios
+      .put<ApiResponse<T>>(url, data, config)
+      .then((res) => res.data);
   }
 
-  async patch<T>(
-    url: string,
-    data?: unknown,
-    config?: Omit<RequestConfig, 'method' | 'body'>
-  ): Promise<ApiResponse<T>> {
-    return this.request<T>(url, { ...config, method: 'PATCH', body: data });
+  patch<T>(url: string, data?: unknown, config?: AxiosRequestConfig) {
+    return this.axios
+      .patch<ApiResponse<T>>(url, data, config)
+      .then((res) => res.data);
   }
 
-  async delete<T>(
-    url: string,
-    config?: Omit<RequestConfig, 'method'>
-  ): Promise<ApiResponse<T>> {
-    return this.request<T>(url, { ...config, method: 'DELETE' });
+  delete<T>(url: string, config?: AxiosRequestConfig) {
+    return this.axios
+      .delete<ApiResponse<T>>(url, config)
+      .then((res) => res.data);
   }
 }
 
-// Singleton-Instanz erstellen
-const apiClient = new ApiClient(
-  API_BASE_URL,
-  { 'Content-Type': 'application/json' },
-  API_TIMEOUT
-);
-
-export default apiClient;
+export default new ApiClient();

--- a/src/client/src/api/services/authService.ts
+++ b/src/client/src/api/services/authService.ts
@@ -1,5 +1,5 @@
 // src/api/services/authService.ts
-import { AUTH_ENDPOINTS } from '../../config/endpoints';
+import { AUTH_ENDPOINTS, PROFILE_ENDPOINTS } from '../../config/endpoints';
 import { LoginRequest } from '../../types/contracts/requests/LoginRequest';
 import { ApiResponse } from '../../types/common/ApiResponse';
 import {
@@ -15,6 +15,7 @@ import {
   getToken,
   setRefreshToken,
   setToken,
+  removeToken,
 } from '../../utils/authHelpers';
 import apiClient from '../apiClient';
 
@@ -102,7 +103,7 @@ const authService = {
     try {
       const response = await apiClient.post<
         ApiResponse<TokenRefreshApiResponse>
-      >('/refresh-token', {
+      >(AUTH_ENDPOINTS.REFRESH_TOKEN, {
         token: currentToken,
         refreshToken: currentRefreshToken,
       });
@@ -143,7 +144,7 @@ const authService = {
    */
   updateProfile: async (profileData: UpdateProfileRequest): Promise<User> => {
     const response = await apiClient.post<ApiResponse<User>>(
-      '/users/profile',
+      PROFILE_ENDPOINTS.UPDATE,
       profileData
     );
     return response.data.data;
@@ -156,7 +157,7 @@ const authService = {
    */
   uploadProfilePicture: async (formData: FormData): Promise<User> => {
     const response = await apiClient.post<ApiResponse<User>>(
-      '/users/upload-avatar',
+      PROFILE_ENDPOINTS.UPLOAD_AVATAR,
       formData,
       {
         headers: {
@@ -175,7 +176,10 @@ const authService = {
   changePassword: async (
     passwordData: ChangePasswordRequest
   ): Promise<void> => {
-    await apiClient.post<ApiResponse<void>>('/change-password', passwordData);
+    await apiClient.post<ApiResponse<void>>(
+      AUTH_ENDPOINTS.CHANGE_PASSWORD,
+      passwordData
+    );
     // Bei void-Responses geben wir nichts zurück
   },
 
@@ -185,7 +189,7 @@ const authService = {
    * @returns Erfolg-/Fehlermeldung
    */
   forgotPassword: async (email: string): Promise<void> => {
-    await apiClient.post<ApiResponse<void>>('/request-password-reset', {
+    await apiClient.post<ApiResponse<void>>(AUTH_ENDPOINTS.FORGOT_PASSWORD, {
       email,
     });
     // Bei void-Responses geben wir nichts zurück
@@ -198,7 +202,7 @@ const authService = {
    * @returns Erfolg-/Fehlermeldung
    */
   resetPassword: async (token: string, password: string): Promise<void> => {
-    await apiClient.post<ApiResponse<void>>('/reset-password', {
+    await apiClient.post<ApiResponse<void>>(AUTH_ENDPOINTS.RESET_PASSWORD, {
       token,
       password,
     });
@@ -211,11 +215,7 @@ const authService = {
    */
   logout: async (): Promise<void> => {
     // Hier könnte man einen API-Call machen, um das Token serverseitig zu invalidieren
-    // Für jetzt entfernen wir nur die lokalen Tokens
-    localStorage.removeItem('access_token');
-    localStorage.removeItem('refresh_token');
-    sessionStorage.removeItem('access_token');
-    sessionStorage.removeItem('refresh_token');
+    removeToken();
     return Promise.resolve();
   },
 };


### PR DESCRIPTION
## Summary
- switch custom fetch wrapper to axios with interceptors
- clean up auth service endpoints and logout handling

## Testing
- `npm run build` *(fails: Cannot find module)*
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_685951dbb06483298ada402347895123