### PR TITLE
Fix client endpoint mappings

### DIFF
--- a/src/client/src/api/services/appointmentService.ts
+++ b/src/client/src/api/services/appointmentService.ts
@@ -16,7 +16,7 @@ const appointmentService = {
    */
   getAppointments: async (): Promise<Appointment[]> => {
     const response = await apiClient.get<Appointment[]>(
-      APPOINTMENT_ENDPOINTS.GET_ALL
+      APPOINTMENT_ENDPOINTS.GET_MY
     );
     return response.data;
   },
@@ -58,10 +58,11 @@ const appointmentService = {
     appointmentId: string,
     status: AppointmentStatus
   ): Promise<AppointmentResponse> => {
-    const response = await apiClient.post<AppointmentResponse>(
-      APPOINTMENT_ENDPOINTS.RESPOND,
-      { appointmentId, status }
-    );
+    const endpoint =
+      status === AppointmentStatus.Confirmed
+        ? `${APPOINTMENT_ENDPOINTS.ACCEPT}/${appointmentId}/accept`
+        : `${APPOINTMENT_ENDPOINTS.CANCEL}/${appointmentId}/cancel`;
+    const response = await apiClient.post<AppointmentResponse>(endpoint);
     return response.data;
   },
 
@@ -74,7 +75,7 @@ const appointmentService = {
     appointmentId: string
   ): Promise<AppointmentResponse> => {
     const response = await apiClient.post<AppointmentResponse>(
-      `${APPOINTMENT_ENDPOINTS.CANCEL}/${appointmentId}`
+      `${APPOINTMENT_ENDPOINTS.CANCEL}/${appointmentId}/cancel`
     );
     return response.data;
   },
@@ -88,7 +89,7 @@ const appointmentService = {
     appointmentId: string
   ): Promise<AppointmentResponse> => {
     const response = await apiClient.post<AppointmentResponse>(
-      `${APPOINTMENT_ENDPOINTS.COMPLETE}/${appointmentId}`
+      `${APPOINTMENT_ENDPOINTS.CANCEL}/${appointmentId}/complete`
     );
     return response.data;
   },

--- a/src/client/src/api/services/skillsService.ts
+++ b/src/client/src/api/services/skillsService.ts
@@ -45,7 +45,7 @@ const SkillService = {
     pageSize = 12
   ): Promise<PaginatedResponse<Skill>> => {
     const response = await apiClient.get<PaginatedResponse<Skill>>(
-      `${SKILL_ENDPOINTS.SEARCH_SKILLS}?query=${query}&page=${page}&pageSize=${pageSize}`
+      `${SKILL_ENDPOINTS.GET_SKILLS}?searchTerm=${query}&page=${page}&pageSize=${pageSize}`
     );
     return response.data;
   },
@@ -56,7 +56,7 @@ const SkillService = {
     pageSize = 12
   ): Promise<PaginatedResponse<Skill>> => {
     const response = await apiClient.get<PaginatedResponse<Skill>>(
-      `${SKILL_ENDPOINTS.GET_USER_SKILLS}?page=${page}&pageSize=${pageSize}`
+      `${SKILL_ENDPOINTS.GET_MY_SKILLS}?page=${page}&pageSize=${pageSize}`
     );
     return response.data;
   },
@@ -64,7 +64,7 @@ const SkillService = {
   // GET /user/skills/{id}
   getUserSkillById: async (skillId: string): Promise<Skill> => {
     const response = await apiClient.get<Skill>(
-      `${SKILL_ENDPOINTS.GET_USER_SKILLS}/${skillId}`
+      `${SKILL_ENDPOINTS.GET_MY_SKILLS}/${skillId}`
     );
     return response.data;
   },
@@ -76,7 +76,7 @@ const SkillService = {
     pageSize = 12
   ): Promise<PaginatedResponse<Skill>> => {
     const response = await apiClient.get<PaginatedResponse<Skill>>(
-      `${SKILL_ENDPOINTS.SEARCH_USER_SKILLS}?query=${query}&page=${page}&pageSize=${pageSize}`
+      `${SKILL_ENDPOINTS.GET_MY_SKILLS}?searchTerm=${query}&page=${page}&pageSize=${pageSize}`
     );
     return response.data;
   },

--- a/src/client/src/api/services/videoCallService.ts
+++ b/src/client/src/api/services/videoCallService.ts
@@ -25,14 +25,13 @@ const videoCallService = {
 
   /**
    * Beendet einen Videoanruf
-   * @param roomId - ID des Anrufraums
+   * @param sessionId - ID des Anrufraums
    * @returns Erfolg-/Fehlermeldung
    */
-  endCall: async (roomId: string): Promise<void> => {
-    const response = await apiClient.post<void>(VIDEOCALL_ENDPOINTS.END_CALL, {
-      roomId,
-      action: 'end',
-    });
+  endCall: async (sessionId: string): Promise<void> => {
+    const response = await apiClient.post<void>(
+      `${VIDEOCALL_ENDPOINTS.END_CALL}/${sessionId}/end`
+    );
     return response.data;
   },
 
@@ -47,9 +46,8 @@ const videoCallService = {
     durationInSeconds: number
   ): Promise<void> => {
     const response = await apiClient.post<void>(
-      `${VIDEOCALL_ENDPOINTS.CONFIG}/info`,
+      `${VIDEOCALL_ENDPOINTS.DETAILS}/${roomId}/info`,
       {
-        roomId,
         durationInSeconds,
       }
     );
@@ -64,9 +62,8 @@ const videoCallService = {
    */
   reportIssue: async (roomId: string, issue: string): Promise<void> => {
     const response = await apiClient.post<void>(
-      `${VIDEOCALL_ENDPOINTS.CONFIG}/report`,
+      `${VIDEOCALL_ENDPOINTS.DETAILS}/${roomId}/report`,
       {
-        roomId,
         issue,
       }
     );

--- a/src/client/src/config/endpoints.ts
+++ b/src/client/src/config/endpoints.ts
@@ -13,8 +13,11 @@ export const AUTH_ENDPOINTS = {
   LOGIN: '/api/users/login',
   REGISTER: '/api/users/register',
   PROFILE: '/api/users/profile',
+  VERIFY_EMAIL: '/api/users/verify-email',
+  GENERATE_2FA: '/api/users/2fa/generate',
+  VERIFY_2FA: '/api/users/2fa/verify',
   CHANGE_PASSWORD: '/api/users/change-password',
-  FORGOT_PASSWORD: '/api/users/forgot-password',
+  FORGOT_PASSWORD: '/api/users/request-password-reset',
   RESET_PASSWORD: '/api/users/reset-password',
   REFRESH_TOKEN: '/api/users/refresh-token'
 };
@@ -24,14 +27,18 @@ export const AUTH_ENDPOINTS = {
  */
 export const SKILL_ENDPOINTS = {
   GET_SKILLS: '/api/skills',
-  GET_USER_SKILLS: '/api/user/skills',
-  SEARCH_SKILLS: '/api/skills/search',
-  SEARCH_USER_SKILLS: '/api/user/skills/search',
+  GET_MY_SKILLS: '/api/my/skills',
+  GET_USER_SKILLS: '/api/users', // + /{userId}/skills
   CREATE_SKILL: '/api/skills',
   UPDATE_SKILL: '/api/skills',
   DELETE_SKILL: '/api/skills',
+  RATE_SKILL: '/api/skills', // + /{skillId}/rate
+  ENDORSE_SKILL: '/api/skills', // + /{skillId}/endorse
   CATEGORIES: '/api/categories',
-  PROFICIENCY_LEVELS: '/api/proficiencylevels',
+  PROFICIENCY_LEVELS: '/api/proficiency-levels',
+  ANALYTICS_STATS: '/api/skills/analytics/statistics',
+  ANALYTICS_TAGS: '/api/skills/analytics/popular-tags',
+  RECOMMENDATIONS: '/api/skills/recommendations',
 };
 
 /**
@@ -39,38 +46,44 @@ export const SKILL_ENDPOINTS = {
  */
 export const MATCHMAKING_ENDPOINTS = {
   FIND_MATCH: '/api/matches/find',
-  GET_MATCH: '/api/matches', // + /{matchSessionId}
-  ACCEPT_MATCH: '/api/matches/accept', // + /{matchSessionId}
-  REJECT_MATCH: '/api/matches/reject', // + /{matchSessionId}
-  GET_USER_MATCHES: '/api/matches',
+  GET_MATCH: '/api/matches', // + /{matchId}
+  ACCEPT_MATCH: '/api/matches', // + /{matchId}/accept
+  REJECT_MATCH: '/api/matches', // + /{matchId}/reject
+  GET_MY_MATCHES: '/api/my/matches',
+  STATISTICS: '/api/matches/statistics',
 };
 
 /**
  * Termin-Endpunkte
  */
 export const APPOINTMENT_ENDPOINTS = {
-  CREATE: '/api/appointments/create',
-  GET_ALL: '/api/appointments',
-  RESPOND: '/api/appointments/respond',
+  CREATE: '/api/appointments',
+  GET_MY: '/api/my/appointments',
   GET_SINGLE: '/api/appointments', // + /{appointmentId}
-  CANCEL: '/api/appointments/cancel', // + /{appointmentId}
-  COMPLETE: '/api/appointments/complete', // + /{appointmentId}
+  ACCEPT: '/api/appointments', // + /{appointmentId}/accept
+  CANCEL: '/api/appointments', // + /{appointmentId}/cancel
 };
 
 /**
  * Videoanruf-Endpunkte
  */
 export const VIDEOCALL_ENDPOINTS = {
-  CONFIG: '/api/videocall', // mit appointmentId als Query-Parameter
-  END_CALL: '/api/videocall', // POST mit roomId im Body
-  SIGNALING: '/api/videocall/hub', // SignalR-Hub
+  CREATE: '/api/calls/create',
+  JOIN: '/api/calls', // + /{sessionId}/join
+  LEAVE: '/api/calls', // + /{sessionId}/leave
+  START: '/api/calls', // + /{sessionId}/start
+  END_CALL: '/api/calls', // + /{sessionId}/end
+  DETAILS: '/api/calls', // + /{sessionId}
+  MY_CALLS: '/api/my/calls',
+  STATISTICS: '/api/calls/statistics',
+  SIGNALING: '/api/videocall',
 };
 
 /**
  * Benutzerprofilendpunkte
  */
 export const PROFILE_ENDPOINTS = {
-  UPDATE: '/api/users/profile/update',
+  UPDATE: '/api/users/profile',
   UPLOAD_AVATAR: '/api/users/profile/avatar',
   GET_USER: '/api/users', // + /{userId}
   FEEDBACK: '/api/users/feedback',


### PR DESCRIPTION
## Summary
- sync `src/client` endpoints with gateway routes
- update service calls for skills, appointments and video calls

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d81d94e8832989ef2d4c6d1d915b